### PR TITLE
Retain cycle: Eller hur jag lärde mig weak och slutade läcka minne

### DIFF
--- a/TravelJournal2/Model/TripData.swift
+++ b/TravelJournal2/Model/TripData.swift
@@ -12,17 +12,17 @@ import FirebaseFirestore
 import FirebaseStorage
 import SVProgressHUD
 
-protocol TripDelegate {
+protocol TripDelegate: class {
     func SetTripData(description:[String: Any])
     func setTripImg(img:UIImage)
 }
 
-protocol PostDelegate {
+protocol PostDelegate: class {
     func SetPostData(description:[String: Any])
     func setPostImg(img:UIImage)
 }
 
-protocol DataDelegate {
+protocol DataDelegate: class {
     func laddaTabell()
 }
 
@@ -49,9 +49,9 @@ struct Post {
 }
 
 class TripData {
-    var tripDel: TripDelegate?
-    var postDel: PostDelegate?
-    var dataDel: DataDelegate?
+    weak var tripDel: TripDelegate?
+    weak var postDel: PostDelegate?
+    weak var dataDel: DataDelegate?
     
     var trips:[Trip] = []
     var posts:[Post] = []


### PR DESCRIPTION
Skam den som ger sig, vi provar igen! Denna gången på svengelska.

Delegater ska nästan alltid vara weak.

ViewPost och EditPost äger ett TripData object, dvs har en stark referens till det.
Men dom sätter också sig själva som postDel på det objektet. Vilket innebär att TripData har en stark referens till ViewPost och EditPost. Det skapar en cykel som innebär att minnet aldrig kommer frigöras.

På samma sätt så har MyTrips och PostCollectionViewController en stark referens till ett TripData objekt och det objektet har en stark referens tillbaks via dataDel propertyn som dom sätter sig själva som.

Lösningen är att använda svaga referenser för delegaterna som inte ökar retain räknaren så minnet kan frigöras när ViewPost/EditPost/MyTrips/PostCollectionViewController inte längre används.

https://docs.swift.org/swift-book/LanguageGuide/AutomaticReferenceCounting.html